### PR TITLE
for fixing, _l2_regularizer_00004 = tf.keras.regularizers.l2(l=0.00004), TypeError: L2.__init__() got an unexpected keyword argument 'l'

### DIFF
--- a/tf_pose/network_base.py
+++ b/tf_pose/network_base.py
@@ -16,7 +16,7 @@ DEFAULT_PADDING = 'SAME'
 _init_xavier = tf.initializers.GlorotUniform()
 _init_norm = tf.initializers.TruncatedNormal(stddev=0.01)
 _init_zero = tf.zeros_initializer()
-_l2_regularizer_00004 = tf.keras.regularizers.l2(l=0.00004)
+_l2_regularizer_00004 = tf.keras.regularizers.l2(l2=0.00004)
 _l2_regularizer_convb = tf.keras.regularizers.l2(common.regularizer_conv)
 
 


### PR DESCRIPTION
The line of code is giving error because,  TensorFlow 2.x uses different argument names for certain functions, including the L2 regularizer. In TensorFlow 2.x, the correct argument name is l2 instead of l.